### PR TITLE
Initial Implementation

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,7 @@
+# marks
+
+> A URI bookmarking utiltity.
+
+If you use [surf][surf] you might want to keep your bookmarks around.
+
+surf: https://surf.suckless.org

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/benjic/marks/lib"
+	"github.com/spf13/cobra"
+)
+
+const (
+	addUse              = `add url`
+	addShortDescription = `inserts a given URL into the bookmark collection`
+)
+
+func init() {
+	RootCommand.AddCommand(addCommand)
+}
+
+var addCommand = &cobra.Command{
+	Use:   addUse,
+	Short: addShortDescription,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("A URL must be provided")
+		}
+
+		e, err := lib.NewEntry(args[0])
+
+		if err != nil {
+			return err
+		}
+
+		file, err := getBookmarksFile()
+		if err != nil {
+			fmt.Println("cant get file")
+			return err
+		}
+		defer file.Close()
+
+		provider, err := lib.NewProvider(file)
+
+		if err := provider.Add(e); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	rootUse = `marks`
+)
+
+// RootCommand is the entry command for the marks program.
+var RootCommand = cobra.Command{
+	Use: rootUse,
+}

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/benjic/marks/lib"
+	"github.com/spf13/cobra"
+)
+
+const (
+	suggestUse              = `suggest {term}`
+	suggestShortDescription = `returns a list of bookmarks for the given terms`
+)
+
+func init() {
+	RootCommand.AddCommand(suggest)
+}
+
+var suggest = &cobra.Command{
+	Use:   suggestUse,
+	Short: suggestShortDescription,
+	RunE: func(command *cobra.Command, args []string) error {
+		file, err := getBookmarksFile()
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		provider, err := lib.NewProvider(file)
+
+		if err != nil {
+			return err
+		}
+
+		for _, suggestion := range provider.Suggest(args) {
+			fmt.Println(suggestion.URL())
+		}
+
+		return nil
+	},
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+	"os/user"
+)
+
+const (
+	defaultPermissions = 0770
+)
+
+func getDataPath() (string, error) {
+	u, err := user.Current()
+
+	if err != nil {
+		return "", err
+	}
+
+	path := u.HomeDir + "/.marks"
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(path, defaultPermissions); err != nil {
+			return "", err
+		}
+	}
+
+	return path, nil
+}
+
+func getBookmarksFile() (*os.File, error) {
+	dataPath, err := getDataPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return os.OpenFile(dataPath+"/bookmarks", os.O_RDWR|os.O_CREATE, defaultPermissions)
+}

--- a/lib/entry.go
+++ b/lib/entry.go
@@ -1,0 +1,30 @@
+package lib
+
+import "net/url"
+
+// An Entry represents a resource.
+type Entry interface {
+	// ID provides a way to uniformly identify an Entry.
+	ID() string
+
+	// URL provides the resource location of an Entry.
+	URL() *url.URL
+}
+
+type entry struct {
+	u *url.URL
+}
+
+func (e *entry) ID() string    { return e.u.String() }
+func (e *entry) URL() *url.URL { return e.u }
+
+// NewEntry creates a new Entry for the given URI string.
+func NewEntry(value string) (Entry, error) {
+	u, err := url.Parse(value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &entry{u}, nil
+}

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// A Provider is a source of URLs.
+type Provider interface {
+	// Add includes a given value.
+	Add(value Entry) error
+
+	// Suggest takes an input value and returns a list of suggest values.
+	Suggest(terms []string) []Entry
+}
+
+type provider struct {
+	io.ReadWriter
+	entries map[string]Entry
+}
+
+func (p *provider) Add(value Entry) error {
+	if _, ok := p.entries[value.ID()]; !ok {
+		p.entries[value.ID()] = value
+		_, err := p.Write([]byte(value.URL().String() + "\r\n"))
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *provider) Suggest(terms []string) []Entry {
+	results := make([]Entry, 0)
+
+	for _, e := range p.entries {
+		u := e.URL().String()
+
+		if matchesAllTerms(u, terms) {
+			results = append(results, e)
+		}
+	}
+
+	return results
+}
+
+// NewProvider establishes a provider which draws entries from the given
+// filepath.
+func NewProvider(rw io.ReadWriter) (Provider, error) {
+	scanner := bufio.NewScanner(rw)
+	entries := make(map[string]Entry, 0)
+
+	for scanner.Scan() {
+		entry, err := NewEntry(scanner.Text())
+
+		if err != nil {
+			return nil, err
+		}
+
+		entries[entry.ID()] = entry
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &provider{rw, entries}, nil
+}
+
+func matchesAllTerms(u string, terms []string) bool {
+	for _, term := range terms {
+		if !strings.Contains(u, term) {
+			return false
+		}
+	}
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/benjic/marks/cmd"
+)
+
+func main() {
+	if err := cmd.RootCommand.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}


### PR DESCRIPTION
## Library

The addition of the `Provider` and `Entry` types abstract the collection of bookmarks that are persisted against a given `ReadWriter`.  An entry can be inserted via the `Add` call, which is deduped against the current list of bookmarks. If the the in-memory collection is updated, the value is written to the the underlying `readWriter`.

The `Suggest`  method of the provider allows a consumer to pass a list of terms. Each of which is matched as a sub-string of any given bookmark. A list of entries is returned.

## CLI

Two commands are added to facilitate interacting the with the provider. A file is used as the `ReadWriter` that the provider persists to. 

A consumer can add a URL to be included as a bookmark.

```bash
$ > marks add https://mastodon.social
```

A consumer can get a list of entries for a collection of search terms. Any bookmark that matches ALL the given terms.

```bash
$ > marks suggest
https://github.com/benjic/marks
https://github.com/coreos/rkt
https://mastodon.social
https://github.com/benjic/farnsworth

$ > marks suggest github
https://github.com/benjic/marks
https://github.com/coreos/rkt
https://github.com/benjic/farnsworth

$ > marks suggest github benjic
https://github.com/benjic/marks
https://github.com/benjic/farnsworth
```

